### PR TITLE
Use RBAC generation and kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,22 +23,15 @@ run: generate fmt vet
 install: 
 	kubectl apply -f config/crds/runtime_v1alpha1_function.yaml
 
-# CreateResource creates a resource in the cluster
-create-resource:
-	kubectl apply -f config/samples
-
-# DeleteResource creates a resource in the cluster
-delete-resource:
-	kubectl delete -f config/samples
-
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-# deploy: manifests
-# 	kubectl apply -f config/crds
-# 	kustomize build config/default | kubectl apply -f -
+deploy: manifests
+	kubectl apply -f config/crds
+	kustomize build config/default | kubectl apply -f -
+	kubectl apply -f config/config.yaml
 
 # Generate manifests e.g. CRD, RBAC etc.
-# manifests:
-	# go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
+manifests:
+	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 
 # Run go fmt against code
 fmt:

--- a/README.md
+++ b/README.md
@@ -52,15 +52,11 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/v0
 --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
 ```
 
-modify config/samples/config.yaml to include your docker.io credentials (base64 encoded) and update the dockerregistry value to your docker.io username
-
-apply the configuration
-
-`kubectl apply -f config/samples/config.yaml`
+modify `config/config.yaml` to include your docker.io credentials (base64 encoded) and update the dockerregistry value to your docker.io username
 
 ### Local Deployment
 
-#### Manager running locally
+#### Manager running locally`
 
 Install the CRD to a local Kubernetes cluster:
 
@@ -78,8 +74,7 @@ make run
 
 ```bash
 eval $(minikube docker-env)
-make docker-build IMG=controller
-
+make docker-build
 make install
 make deploy
 ```
@@ -91,8 +86,8 @@ Then run the following commands:
 
 ```bash
 make install
-make docker-build IMG=
-make docker-push IMG=
+make docker-build
+make docker-push
 make deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ modify `config/config.yaml` to include your docker.io credentials (base64 encode
 
 ### Local Deployment
 
-#### Manager running locally`
+#### Manager running locally
 
 Install the CRD to a local Kubernetes cluster:
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Runtime
 
-### Development
+## Development
 
-#### Test
+### Test
 
-```
+```bash
 make test
 ```
+
 ### Setup development environment (mac)
 
 start a beefy minikube
-```@sh
+
+```bash
 minikube start \
   --memory=12288 \
   --cpus=4 \
@@ -21,7 +23,8 @@ minikube start \
 ```
 
 install istio
-```
+
+```bash
 kubectl apply \
   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml &&
 curl -L https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml \
@@ -30,7 +33,8 @@ curl -L https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/ist
 ```
 
 install knative
-```
+
+```bash
 kubectl apply \
   --selector knative.dev/crd-install=true \
   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
@@ -40,7 +44,8 @@ kubectl apply \
 ```
 
 install knative part2
-```
+
+```bash
 kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
 --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
 --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
@@ -53,34 +58,52 @@ apply the configuration
 
 `kubectl apply -f config/samples/config.yaml`
 
-#### Install the CRD to a local Kubernetes cluster
+### Local Deployment
 
-```
+#### Manager running locally
+
+Install the CRD to a local Kubernetes cluster:
+
+```bash
 make install
 ```
-#### Build and run the manager
-```
+
+Run the controller on your machine:
+
+```bash
 make run
 ```
 
-# Create a docker image
+#### Manager running inside k8s cluster
 
-```
-make docker-build IMG=<img-name>
-```
+```bash
+eval $(minikube docker-env)
+make docker-build IMG=controller
 
-# Push the docker image to a configured container registry
-
-```
-make docker-push IMG=<img-name>
+make install
+make deploy
 ```
 
-#### Run the examples
+### Prod Deployment
+
+Uncomment `manager_image_patch_dev` in `kustomization.yaml`
+Then run the following commands:
+
+```bash
+make install
+make docker-build IMG=
+make docker-push IMG=
+make deploy
 ```
+
+### Run the examples
+
+```bash
 kubectl apply -f config/samples/runtime_v1alpha1_function.yaml
 ```
 
 access the function
-```
+
+```bash
 curl -v -H "Host: $(kubectl get ksvc sample --no-headers | awk '{print $2}')" http://$(minikube ip):$(kubectl get svc istio-ingressgateway --namespace istio-system --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 ```

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,8 @@ import (
 )
 
 func main() {
+	var metricsAddr string
+	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,11 +63,12 @@ data:
   username: 
   # password for the account
   # echo -n $PASSWORD | base64 
-  password: 
+  password:
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: runtime-controller
+  namespace: runtime-system
 secrets:
 - name: docker-reg-credential

--- a/config/crds/runtime_v1alpha1_function.yaml
+++ b/config/crds/runtime_v1alpha1_function.yaml
@@ -10,9 +10,6 @@ spec:
   names:
     kind: Function
     plural: functions
-    singular: function
-    shortNames:
-    - fn
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -44,8 +41,8 @@ spec:
               description: function defines the content of a function
               type: string
             functionContentType:
-              description: functionContentType defines file content type (plaintext/
-                base64)
+              description: functionContentType defines file content type (plaintext
+                or base64)
               type: string
             runtime:
               description: runtime is the programming language used for a function

--- a/config/crds/serving_v1alpha1_service.yaml
+++ b/config/crds/serving_v1alpha1_service.yaml
@@ -19,6 +19,8 @@ spec:
   scope: Namespaced
   version: v1alpha1
 status:
+  conditions: []
+  storedVersions: []
   acceptedNames:
     categories:
     - all

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,8 +18,8 @@ namePrefix: runtime-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
+- ../rbac/manager_role.yaml
+- ../rbac/manager_role_binding.yaml
 - ../manager/manager.yaml
   # Comment the following 3 lines if you want to disable
   # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
@@ -29,7 +29,10 @@ resources:
 - ../rbac/auth_proxy_role_binding.yaml
 
 patches:
-- manager_image_patch.yaml
+# patch for prod:
+# - manager_image_patch.yaml
+# patch for dev:
+- manager_image_patch_dev.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
@@ -40,6 +43,7 @@ patches:
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
+- manager_cluster_role_binding_patch.yaml
 
 vars:
 - name: WEBHOOK_SECRET_NAME

--- a/config/default/manager_cluster_role_binding_patch.yaml
+++ b/config/default/manager_cluster_role_binding_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: runtime-controller
+  namespace: runtime-system

--- a/config/default/manager_image_patch_dev.yaml
+++ b/config/default/manager_image_patch_dev.yaml
@@ -13,3 +13,9 @@ spec:
         app: runtime-controller
     spec:
       serviceAccount: runtime-controller
+      containers:
+      - command:
+        - /manager
+        # this is required to use the local minikube built image
+        imagePullPolicy: Never
+        name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: controller:latest
+        image: runtime-controller:latest
         imagePullPolicy: Always
         name: manager
         env:

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -1,12 +1,7 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: manager-role
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:
@@ -86,45 +81,40 @@ rules:
   - list
   - update
   - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manager-role
-subjects:
-- kind: ServiceAccount
-  name: manager-role
-  namespace: default
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: controller-manager
-spec:
-  selector:
-    matchLabels:
-      app: runtime-controller
-  serviceName: runtime
-  template:
-    metadata:
-      labels:
-        app: runtime-controller
-    spec:
-      serviceAccount: manager-role
-      containers:
-      # Change the value of image field below to your controller image URL
-      - image: runtime-controller
-        imagePullPolicy: IfNotPresent
-        name: manager-role
-        env: 
-        - name: CONTROLLER_CONFIGMAP
-          value: "controller-config"
-        - name: CONTROLLER_CONFIGMAP_NS
-          value: "kyma-system"
-
-
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/rbac/manager_role_binding.yaml
+++ b/config/rbac/manager_role_binding.yaml
@@ -9,5 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: ""

--- a/pkg/controller/function/function_controller.go
+++ b/pkg/controller/function/function_controller.go
@@ -93,10 +93,13 @@ type ReconcileFunction struct {
 
 // Reconcile reads that state of the cluster for a Function object and makes changes based on the state read
 // and what is in the Function.Spec
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=runtime.kyma-project.io,resources=functions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=runtime.kyma-project.io,resources=functions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="runtime.kyma-project.io",resources=functions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="runtime.kyma-project.io",resources=functions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list
+// +kubebuilder:rbac:groups=";apps;extensions",resources=deployments,verbs=create;get;delete;list;update;patch
 func (r *ReconcileFunction) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 
 	fnConfigName := "fn-config"


### PR DESCRIPTION
The current state of this repo fails with errors when trying to run `make deploy`.
Instead of using `kustomize`, hand-crafted yaml files have been used and the controller has been run only with `make run` (which runs it locally instead of running it inside the k8s cluster).

Changes:
- Use and fix RBAC generation from kubebuilder annotations
- Use kustomize as proposed by initial kubebuilder setup
- Fix small problems while trying to get `make deploy` running
- Generated rbac yaml are prefixed with `manager` and  not `rbac_` anymore