### PR TITLE
4223 implement webhook for knative function crd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,68 @@
 # Runtime
 
+## Requirements & Scaffolding
+
+The code got scaffolded with `kubebuilder==1.0.8`.
+Make sure to use `kustomize==1.0.10`. Otherwise you will get security errors.
+
+The code has been scaffoled using the following commands:
+
+```bash
+kubebuilder init --domain kyma-project.io
+kubebuilder create api --group runtime --version v1alpha1 --kind Function
+kubebuilder alpha webhook --group runtime --version v1alpha1 --kind Function --type mutating
+```
+
+## WebHook Readme
+
+The following section shows some links on webhooks and how the webhook mutates and validates the example functions.
+
+### Links
+
+- <https://book-v1.book.kubebuilder.io/beyond_basics/sample_webhook.html>
+- <https://github.com/morvencao/kube-mutating-webhook-tutorial/blob/master/medium-article.md>
+
+### Alternative
+
+[Custom Resource Validation Schema](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#publish-validation-schema-in-openapi-v2)
+
+### Examples
+
+#### Mutation
+
+Deploy Function:
+
+```bash
+kubectl apply -f config/samples/runtime_v1alpha1_function.yaml
+```
+
+Verify default values got set:
+
+```bash
+$ kubectl get functions.runtime.kyma-project.io function-sample -oyaml
+...
+spec:
+  function: |
+    module.exports = {
+        main: function(event, context) {
+          return 'Hello World'
+        }
+      }
+  functionContentType: plaintext
+  runtime: nodejs8
+  size: S
+  timeout: 180
+```
+
+#### Validation
+
+Deploy Function:
+
+```bash
+$ kubectl apply -f config/samples/runtime_v1alpha1_function_invalid.yaml
+Error from server (InternalError): error when creating "config/samples/runtime_v1alpha1_function_invalid.yaml": Internal error occurred: admission webhook "mutating-create-function.kyma-project.io" denied the request: runtime should be one of 'nodejs6,nodejs8'
+```
+
 ## Development
 
 ### Test
@@ -8,7 +71,7 @@
 make test
 ```
 
-### Setup development environment (mac)
+### Setup knative
 
 start a beefy minikube
 
@@ -71,6 +134,8 @@ make run
 ```
 
 #### Manager running inside k8s cluster
+
+This workflow needs to be used until [Come up with webhook developer workflow to test it locally #400](https://github.com/kubernetes-sigs/kubebuilder/issues/400) is fixed.
 
 ```bash
 eval $(minikube docker-env)

--- a/config/samples/runtime_v1alpha1_webhook_defaults_function.yaml
+++ b/config/samples/runtime_v1alpha1_webhook_defaults_function.yaml
@@ -1,0 +1,18 @@
+apiVersion: runtime.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: function-webhook-defaults
+spec:
+  function: |
+    module.exports = {
+        main: function(event, context) {
+          return 'Hello World'
+        }
+      }
+  functionContentType: "plaintext"
+  # use default values:
+  # size: "L"
+  # runtime: "nodejs8"
+  # timeout: 20

--- a/config/samples/runtime_v1alpha1_webhook_invalid_function.yaml
+++ b/config/samples/runtime_v1alpha1_webhook_invalid_function.yaml
@@ -1,0 +1,18 @@
+apiVersion: runtime.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: function-webhook-invalid
+spec:
+  function: |
+    module.exports = {
+        main: function(event, context) {
+          return 'Hello World'
+        }
+      }
+  functionContentType: "plaintext"
+  size: "L"
+  runtime: "nodejs5"
+  timeout: 20
+  foo: bar

--- a/pkg/webhook/add_default_server.go
+++ b/pkg/webhook/add_default_server.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Kyma Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	server "github.com/kyma-incubator/runtime/pkg/webhook/default_server"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create webhook servers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, server.Add)
+}

--- a/pkg/webhook/default_server/add_mutating_function.go
+++ b/pkg/webhook/default_server/add_mutating_function.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kyma Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"github.com/kyma-incubator/runtime/pkg/webhook/default_server/function/mutating"
+)
+
+func init() {
+	for k, v := range mutating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range mutating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/pkg/webhook/default_server/function/mutating/create_webhook.go
+++ b/pkg/webhook/default_server/function/mutating/create_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Kyma Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	runtimev1alpha1 "github.com/kyma-incubator/runtime/pkg/apis/runtime/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+func init() {
+	builderName := "mutating-create-function"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName + ".kyma-project.io").
+		Path("/" + builderName).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Create).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&runtimev1alpha1.Function{})
+}

--- a/pkg/webhook/default_server/function/mutating/function_create_handler.go
+++ b/pkg/webhook/default_server/function/mutating/function_create_handler.go
@@ -1,0 +1,153 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	runtimev1alpha1 "github.com/kyma-incubator/runtime/pkg/apis/runtime/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+var (
+	functionSizes        = []string{"S", "M", "L", "XL"}
+	runtimes             = []string{"nodejs6", "nodejs8"}
+	functionContentTypes = []string{"plaintext", "base64"}
+	log                  = logf.Log.WithName("webhook")
+)
+
+func init() {
+	log.Info("init")
+	webhookName := "mutating-create-function"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &FunctionCreateHandler{})
+}
+
+// FunctionCreateHandler handles Function
+type FunctionCreateHandler struct {
+	Client client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+// Mutates function values
+func (h *FunctionCreateHandler) mutatingFunctionFn(obj *runtimev1alpha1.Function) {
+	if obj.Spec.Size == "" {
+		obj.Spec.Size = "S"
+	}
+	if obj.Spec.Runtime == "" {
+		obj.Spec.Runtime = "nodejs8"
+	}
+	if obj.Spec.Timeout == 0 {
+		obj.Spec.Timeout = 180
+	}
+	if obj.Spec.FunctionContentType == "" {
+		obj.Spec.FunctionContentType = "plaintext"
+	}
+}
+
+// Validate function values and return an error if the function is not valid
+func (h *FunctionCreateHandler) validateFunctionFn(obj *runtimev1alpha1.Function) error {
+	// function size
+	isValidFunctionSize := false
+	for _, functionSize := range functionSizes {
+		if obj.Spec.Size == functionSize {
+			isValidFunctionSize = true
+			break
+		}
+	}
+	if !isValidFunctionSize {
+		return fmt.Errorf("size should be one of '%v'", strings.Join(functionSizes, ","))
+	}
+
+	// function runtime
+	isValidRuntime := false
+	for _, runtime := range runtimes {
+		if obj.Spec.Runtime == runtime {
+			isValidRuntime = true
+			break
+		}
+	}
+	if !isValidRuntime {
+		return fmt.Errorf("runtime should be one of '%v'", strings.Join(runtimes, ","))
+	}
+
+	// function content type
+	isValidFunctionContentType := false
+	for _, functionContentType := range functionContentTypes {
+		if obj.Spec.FunctionContentType == functionContentType {
+			isValidFunctionContentType = true
+			break
+		}
+	}
+	if !isValidFunctionContentType {
+		return fmt.Errorf("functionContentType should be one of '%v'", strings.Join(functionContentTypes, ","))
+	}
+
+	return nil
+}
+
+var _ admission.Handler = &FunctionCreateHandler{}
+
+// Handle handles admission requests.
+func (h *FunctionCreateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	log.Info("received admission request", "request", req)
+
+	obj := &runtimev1alpha1.Function{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	copy := obj.DeepCopy()
+
+	// mutate values
+	h.mutatingFunctionFn(copy)
+
+	// validate function and return an error describing the validation error if validation fails
+	err = h.validateFunctionFn(copy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponse(obj, copy)
+}
+
+var _ inject.Client = &FunctionCreateHandler{}
+
+// InjectClient injects the client into the FunctionCreateHandler
+func (h *FunctionCreateHandler) InjectClient(c client.Client) error {
+	h.Client = c
+	return nil
+}
+
+var _ inject.Decoder = &FunctionCreateHandler{}
+
+// InjectDecoder injects the decoder into the FunctionCreateHandler
+func (h *FunctionCreateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/pkg/webhook/default_server/function/mutating/function_create_handler_test.go
+++ b/pkg/webhook/default_server/function/mutating/function_create_handler_test.go
@@ -22,6 +22,7 @@ import (
 
 var functionCreateHandler = FunctionCreateHandler{}
 
+// Test that an empty function gets all default values set
 func TestMutation(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
@@ -36,6 +37,7 @@ func TestMutation(t *testing.T) {
 	// mutate function
 	functionCreateHandler.mutatingFunctionFn(function)
 
+	// ensure defaults are set
 	g.Expect(function.Spec).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		"Size":                gomega.BeEquivalentTo("S"),
 		"Timeout":             gomega.BeEquivalentTo(180),
@@ -44,6 +46,7 @@ func TestMutation(t *testing.T) {
 	}))
 }
 
+// Test that all values get validated
 func TestValidation(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/pkg/webhook/default_server/function/mutating/function_create_handler_test.go
+++ b/pkg/webhook/default_server/function/mutating/function_create_handler_test.go
@@ -1,0 +1,195 @@
+package mutating
+
+import (
+	"testing"
+
+	"github.com/appscode/jsonpatch"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	"github.com/onsi/gomega/gstruct"
+
+	runtimev1alpha1 "github.com/kyma-incubator/runtime/pkg/apis/runtime/v1alpha1"
+	"github.com/onsi/gomega"
+
+	"context"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var functionCreateHandler = FunctionCreateHandler{}
+
+func TestMutation(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	function := &runtimev1alpha1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: runtimev1alpha1.FunctionSpec{
+			FunctionContentType: "plaintext",
+			Function:            "foo",
+		},
+	}
+
+	// mutate function
+	functionCreateHandler.mutatingFunctionFn(function)
+
+	g.Expect(function.Spec).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Size":                gomega.BeEquivalentTo("S"),
+		"Timeout":             gomega.BeEquivalentTo(180),
+		"Runtime":             gomega.BeEquivalentTo("nodejs8"),
+		"FunctionContentType": gomega.BeEquivalentTo("plaintext"),
+	}))
+}
+
+func TestValidation(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// wrong runtime
+	function := &runtimev1alpha1.Function{
+		Spec: runtimev1alpha1.FunctionSpec{
+			FunctionContentType: "plaintext",
+			Function:            "foo",
+			Size:                "S",
+			Runtime:             "nodejs4",
+		},
+	}
+	g.Expect(functionCreateHandler.validateFunctionFn(function)).To(gomega.MatchError("runtime should be one of 'nodejs6,nodejs8'"))
+
+	// wrong size
+	function = &runtimev1alpha1.Function{
+		Spec: runtimev1alpha1.FunctionSpec{
+			FunctionContentType: "plaintext",
+			Function:            "foo",
+			Size:                "UnknownSize",
+			Runtime:             "nodejs8",
+		},
+	}
+	g.Expect(functionCreateHandler.validateFunctionFn(function)).To(gomega.MatchError("size should be one of 'S,M,L,XL'"))
+
+	// wrong functionContentType
+	function = &runtimev1alpha1.Function{
+		Spec: runtimev1alpha1.FunctionSpec{
+			FunctionContentType: "UnknownFunctionContentType",
+			Function:            "foo",
+			Size:                "S",
+			Runtime:             "nodejs8",
+		},
+	}
+	g.Expect(functionCreateHandler.validateFunctionFn(function)).To(gomega.MatchError("functionContentType should be one of 'plaintext,base64'"))
+
+}
+
+// Check that a function with invalid parameter values get's rejected by the webhook
+// other value permutations are already covered by unit test TestValidation
+func TestHandleInvalid(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	admissionDecoder, err := admission.NewDecoder(scheme.Scheme)
+	if err != nil {
+		t.Error("Could not create admission decoder")
+	}
+
+	functionCreateHandler := FunctionCreateHandler{
+		Decoder: admissionDecoder,
+	}
+
+	// create an admission request
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind: metav1.GroupVersionKind{
+			Group:   "kyma-project.io",
+			Version: "v1alpha1",
+			Kind:    "Function",
+		},
+		Object: runtime.RawExtension{
+			Raw: []byte(`
+{
+	"metadata": {
+    	"name": "invalid-function",
+    	"uid": "e9137d7d-c318-12e8-bbad-025654321111",
+    	"creationTimestamp": "2019-06-07T12:33:39Z"
+	},
+	"spec": {
+		"function": "",
+    	"functionContentType": "plaintext",
+    	"size": "foo"
+    }
+}
+`),
+		},
+	}
+
+	// call the handler - this is the method called by the webhook server
+	response := functionCreateHandler.Handle(context.TODO(), types.Request{AdmissionRequest: req})
+
+	// ensure function got rejected
+	g.Expect(response.Response.Allowed).To(gomega.BeFalse())
+
+	// ensure that object has not been declined due to decoding issues (4XX error code)
+	// reject functions should return a 500 error code
+	g.Expect(response.Response.Result.Code).To(gomega.Equal(int32(500)))
+
+}
+
+// Check that the default values are added for optional parameters
+func TestHandleDefaults(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// these are the expected patches for an empty function
+	expectedPatches := []jsonpatch.Operation{
+		{
+			Operation: "replace",
+			Path:      "/spec/functionContentType",
+			Value:     "plaintext",
+		},
+		{
+			Operation: "replace",
+			Path:      "/spec/size",
+			Value:     "S",
+		},
+		{
+			Operation: "replace",
+			Path:      "/spec/runtime",
+			Value:     "nodejs8",
+		},
+		{
+			Operation: "add",
+			Path:      "/spec/timeout",
+			Value:     float64(180),
+		},
+	}
+
+	admissionDecoder, err := admission.NewDecoder(scheme.Scheme)
+	if err != nil {
+		t.Error("could not created admission decoder")
+	}
+
+	functionCreateHandler := FunctionCreateHandler{
+		Decoder: admissionDecoder,
+	}
+
+	// create admission request
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind: metav1.GroupVersionKind{
+			Group:   "kyma-project.io",
+			Version: "v1alpha1",
+			Kind:    "Function",
+		},
+	}
+
+	// call handler
+	response := functionCreateHandler.Handle(context.TODO(), types.Request{AdmissionRequest: req})
+
+	// ensure request got accepted and check patches later
+	g.Expect(response.Response.Allowed).To(gomega.BeTrue())
+
+	// check that each received patch matches at least one expected patch
+	for _, actualPatch := range response.Patches {
+		g.Expect(expectedPatches).To(gomega.ContainElement(gomega.BeEquivalentTo(actualPatch)))
+	}
+
+}

--- a/pkg/webhook/default_server/function/mutating/webhooks.go
+++ b/pkg/webhook/default_server/function/mutating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kyma Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)

--- a/pkg/webhook/default_server/server.go
+++ b/pkg/webhook/default_server/server.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kyma Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	log        = logf.Log.WithName("default_server")
+	builderMap = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains all admission webhook handlers.
+	HandlerMap = map[string][]admission.Handler{}
+)
+
+// Add adds itself to the manager
+func Add(mgr manager.Manager) error {
+	ns := os.Getenv("POD_NAMESPACE")
+	if len(ns) == 0 {
+		ns = "default"
+	}
+	secretName := os.Getenv("SECRET_NAME")
+	if len(secretName) == 0 {
+		secretName = "webhook-server-secret"
+	}
+
+	svr, err := webhook.NewServer("foo-admission-server", mgr, webhook.ServerOptions{
+		// TODO(user): change the configuration of ServerOptions based on your need.
+		Port:    9876,
+		CertDir: "/tmp/cert",
+		BootstrapOptions: &webhook.BootstrapOptions{
+			Secret: &types.NamespacedName{
+				Namespace: ns,
+				Name:      secretName,
+			},
+
+			Service: &webhook.Service{
+				Namespace: ns,
+				Name:      "webhook-server-service",
+				// Selectors should select the pods that runs this webhook server.
+				Selectors: map[string]string{
+					"control-plane": "controller-manager",
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	var webhooks []webhook.Webhook
+	for k, builder := range builderMap {
+		handlers, ok := HandlerMap[k]
+		if !ok {
+			log.V(1).Info(fmt.Sprintf("can't find handlers for builder: %v", k))
+			handlers = []admission.Handler{}
+		}
+		wh, err := builder.
+			Handlers(handlers...).
+			WithManager(mgr).
+			Build()
+		if err != nil {
+			return err
+		}
+		webhooks = append(webhooks, wh)
+	}
+
+	return svr.Register(webhooks...)
+}


### PR DESCRIPTION
This merge requests adds a mutating webhook for the function CRD.

- Most code got  scaffolded (see [README](README.md))
- New Code
  - [pkg/webhook/default_server/function/mutating/function_create_handler.go](pkg/webhook/default_server/function/mutating/function_create_handler.go)
- Unit Tests:
  - [pkg/webhook/default_server/function/mutating/function_create_handler_test.go](pkg/webhook/default_server/function/mutating/function_create_handler_test.go)

Issue: https://github.com/kyma-project/kyma/issues/4223